### PR TITLE
Use custom recipes for Colony drops

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
 
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-	modImplementation "software.bernie.geckolib:geckolib-fabric-1.18:3.0.44"
+	modImplementation "software.bernie.geckolib:geckolib-fabric-1.18:${project.geckolib_version}"
 }
 
 processResources {

--- a/example_recipes/spruce_leaf_colony_harvesting_with_bucket.json
+++ b/example_recipes/spruce_leaf_colony_harvesting_with_bucket.json
@@ -1,0 +1,14 @@
+{
+  "type": "ants:colony_harvesting",
+  "hive_ingredient": {
+    "item": "minecraft:spruce_leaves"
+  },
+  "hand_ingredient": {
+    "item": "minecraft:bucket"
+  },
+  "hand_ingredient_count": 2,
+  "result" : {
+    "item": "minecraft:beacon",
+	"count": 5
+  }
+}

--- a/example_recipes/spruce_leaf_colony_shoveling.json
+++ b/example_recipes/spruce_leaf_colony_shoveling.json
@@ -1,0 +1,10 @@
+{
+  "type": "ants:colony_shoveling",
+  "hive_ingredient": {
+    "item": "minecraft:spruce_leaves"
+  },
+  "result" : {
+    "item": "minecraft:diamond",
+	"count": 3
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 	# check these on https://fabricmc.net/develop
 	minecraft_version=1.18.2
-	yarn_mappings=1.18.2+build.1
-	loader_version=0.13.3
+	yarn_mappings=1.18.2+build.3
+	loader_version=0.14.8
 
 # Mod Properties
 	mod_version = 1.0.2
@@ -13,4 +13,5 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = little-ants-1.18.2
 
 # Dependencies
-	fabric_version=0.47.8+1.18.2
+	fabric_version=0.57.0+1.18.2
+	geckolib_version=3.0.52

--- a/src/main/java/toxican/caleb/ants/AntsMain.java
+++ b/src/main/java/toxican/caleb/ants/AntsMain.java
@@ -1,6 +1,11 @@
 package toxican.caleb.ants;
 
 import net.fabricmc.api.ModInitializer;
+import net.fabricmc.fabric.api.object.builder.v1.world.poi.PointOfInterestHelper;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.poi.PointOfInterestType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.bernie.geckolib3.GeckoLib;
 import toxican.caleb.ants.blocks.AntsBlocks;
 import toxican.caleb.ants.damage.AntsDamageSource;
@@ -12,12 +17,6 @@ import toxican.caleb.ants.items.AntsItems;
 import toxican.caleb.ants.particles.AntsParticles;
 import toxican.caleb.ants.recipes.AntsRecipeTypes;
 import toxican.caleb.ants.sounds.AntsSounds;
-import net.fabricmc.fabric.api.object.builder.v1.world.poi.PointOfInterestHelper;
-import net.minecraft.util.Identifier;
-import net.minecraft.world.poi.PointOfInterestType;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class AntsMain implements ModInitializer {
 	public static final String MOD_ID = "ants";

--- a/src/main/java/toxican/caleb/ants/AntsMain.java
+++ b/src/main/java/toxican/caleb/ants/AntsMain.java
@@ -10,6 +10,7 @@ import toxican.caleb.ants.features.bushes.AntsBushes;
 import toxican.caleb.ants.features.bushes.nest_decorator.AntsDecorations;
 import toxican.caleb.ants.items.AntsItems;
 import toxican.caleb.ants.particles.AntsParticles;
+import toxican.caleb.ants.recipes.AntsRecipeTypes;
 import toxican.caleb.ants.sounds.AntsSounds;
 import net.fabricmc.fabric.api.object.builder.v1.world.poi.PointOfInterestHelper;
 import net.minecraft.util.Identifier;
@@ -25,28 +26,30 @@ public class AntsMain implements ModInitializer {
 
 	@Override
 	public void onInitialize() {
-		GeckoLib.initialize();
 		LOGGER.info("Loading models...");
-		AntsEntities.init();
+		GeckoLib.initialize();
 		LOGGER.info("Loading ants...");
-		AntsItems.init();
+		AntsEntities.init();
 		LOGGER.info("Loading items...");
-		AntsBlocks.init();
+		AntsItems.init();
 		LOGGER.info("Loading blocks...");
-		AntsParticles.init();
+		AntsBlocks.init();
 		LOGGER.info("Loading particles...");
-		NEST = PointOfInterestHelper.register(new Identifier("ants", "nest"), 0, 1, AntsBlocks.DIRT_ANT_NEST, AntsBlocks.SAND_ANT_NEST);
+		AntsParticles.init();
 		LOGGER.info("Loading points of interest...");
-		AntsSounds.init();
+		NEST = PointOfInterestHelper.register(new Identifier("ants", "nest"), 0, 1, AntsBlocks.DIRT_ANT_NEST, AntsBlocks.SAND_ANT_NEST);
 		LOGGER.info("Loading sounds...");
-		AntsBushes.init();
+		AntsSounds.init();
 		LOGGER.info("Loading bushes...");
-		AntsDecorations.init();
+		AntsBushes.init();
 		LOGGER.info("Loading decorations...");
-		AntsEnchantments.init();
+		AntsDecorations.init();
 		LOGGER.info("Loading enchantments...");
-		AntsDamageSource.init();
+		AntsEnchantments.init();
 		LOGGER.info("Loading damage sources...");
+		AntsDamageSource.init();
+		LOGGER.info("Loading recipe types...");
+		AntsRecipeTypes.init();
 
 		LOGGER.info("Loaded!");
 	}

--- a/src/main/java/toxican/caleb/ants/blocks/nest/AntNestBlock.java
+++ b/src/main/java/toxican/caleb/ants/blocks/nest/AntNestBlock.java
@@ -1,16 +1,6 @@
 package toxican.caleb.ants.blocks.nest;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Random;
-import net.minecraft.block.AbstractBlock;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockRenderType;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.BlockWithEntity;
-import net.minecraft.block.CampfireBlock;
-import net.minecraft.block.FireBlock;
-import net.minecraft.block.HorizontalFacingBlock;
+import net.minecraft.block.*;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.block.entity.BlockEntityTicker;
 import net.minecraft.block.entity.BlockEntityType;
@@ -25,12 +15,7 @@ import net.minecraft.entity.mob.CreeperEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.WitherSkullEntity;
 import net.minecraft.entity.vehicle.TntMinecartEntity;
-import net.minecraft.item.BlockItem;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemPlacementContext;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
-import net.minecraft.item.ShovelItem;
+import net.minecraft.item.*;
 import net.minecraft.loot.context.LootContext;
 import net.minecraft.loot.context.LootContextParameters;
 import net.minecraft.nbt.NbtCompound;
@@ -56,15 +41,18 @@ import net.minecraft.world.GameRules;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
 import net.minecraft.world.event.GameEvent;
+import org.jetbrains.annotations.Nullable;
 import toxican.caleb.ants.blocks.AntsBlocks;
 import toxican.caleb.ants.blocks.NestTag;
 import toxican.caleb.ants.damage.AntsDamageSource;
 import toxican.caleb.ants.enchantment.AntHelper;
 import toxican.caleb.ants.entities.AntEntity;
-import toxican.caleb.ants.items.AntsItems;
-import org.jetbrains.annotations.Nullable;
 import toxican.caleb.ants.recipes.ColonyHarvestingRecipe;
 import toxican.caleb.ants.recipes.ColonyShovelingRecipe;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
 
 //The Colony Block. Once upon a time they were called Nests and im too lazy to change that in the code
 
@@ -72,7 +60,6 @@ public class AntNestBlock extends BlockWithEntity {
     public static final DirectionProperty FACING = HorizontalFacingBlock.FACING;
     public static final IntProperty CLAY_LEVEL = IntProperty.of("clay_level", 0, 5);
     public static final int FULL_CLAY_LEVEL = 5;
-    private static final int DROPPED_CLAY_COUNT = 3;
 
     public AntNestBlock(AbstractBlock.Settings settings) {
         super(settings);

--- a/src/main/java/toxican/caleb/ants/recipes/AntsRecipeTypes.java
+++ b/src/main/java/toxican/caleb/ants/recipes/AntsRecipeTypes.java
@@ -1,0 +1,46 @@
+package toxican.caleb.ants.recipes;
+
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeSerializer;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.Registry;
+import toxican.caleb.ants.AntsMain;
+
+public class AntsRecipeTypes {
+	
+	public static String COLONY_SHOVELING_ID = "colony_shoveling";
+	public static RecipeSerializer<ColonyShovelingRecipe> COLONY_SHOVELING_SERIALIZER;
+	public static RecipeType<ColonyShovelingRecipe> COLONY_SHOVELING;
+	
+	public static String COLONY_HARVESTING_ID = "colony_harvesting";
+	public static RecipeSerializer<ColonyHarvestingRecipe> COLONY_HARVESTING_SERIALIZER;
+	public static RecipeType<ColonyHarvestingRecipe> COLONY_HARVESTING;
+	
+	static <S extends RecipeSerializer<T>, T extends Recipe<?>> S registerSerializer(String id, S serializer) {
+		return Registry.register(Registry.RECIPE_SERIALIZER, new Identifier(AntsMain.MOD_ID, id), serializer);
+	}
+	
+	static <S extends RecipeType<T>, T extends Recipe<?>> S registerRecipeType(String id, S serializer) {
+		return Registry.register(Registry.RECIPE_TYPE, new Identifier(AntsMain.MOD_ID, id), serializer);
+	}
+	
+	public static void init() {
+		COLONY_SHOVELING_SERIALIZER = registerSerializer(COLONY_SHOVELING_ID, new ColonyShovelingRecipeSerializer(ColonyShovelingRecipe::new));
+		COLONY_SHOVELING = registerRecipeType(COLONY_SHOVELING_ID, new RecipeType<ColonyShovelingRecipe>() {
+			@Override
+			public String toString() {
+				return AntsMain.MOD_ID + ":" + COLONY_SHOVELING_ID;
+			}
+		});
+		
+		COLONY_HARVESTING_SERIALIZER = registerSerializer(COLONY_HARVESTING_ID, new ColonyHarvestingRecipeSerializer(ColonyHarvestingRecipe::new));
+		COLONY_HARVESTING = registerRecipeType(COLONY_HARVESTING_ID, new RecipeType<ColonyHarvestingRecipe>() {
+			@Override
+			public String toString() {
+				return AntsMain.MOD_ID + ":" + COLONY_HARVESTING_ID;
+			}
+		});		
+	}
+	
+}

--- a/src/main/java/toxican/caleb/ants/recipes/ColonyHarvestingRecipe.java
+++ b/src/main/java/toxican/caleb/ants/recipes/ColonyHarvestingRecipe.java
@@ -13,7 +13,6 @@ import toxican.caleb.ants.blocks.AntsBlocks;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Specifies the drop a player gets when using a shovel on a completely filled colony

--- a/src/main/java/toxican/caleb/ants/recipes/ColonyHarvestingRecipe.java
+++ b/src/main/java/toxican/caleb/ants/recipes/ColonyHarvestingRecipe.java
@@ -1,0 +1,129 @@
+package toxican.caleb.ants.recipes;
+
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeSerializer;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.World;
+import toxican.caleb.ants.blocks.AntsBlocks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Specifies the drop a player gets when using a shovel on a completely filled colony
+ * id: the recipes identifier
+ * group: internal group string (mainly used for the recipe book or other mechanisms that group recipes
+ * hiveIngredient: the last food the ants collected in that colony, or one per random
+ * handIngredient: the item the player has to hold in their hand
+ * int handIngredientCount: the amount of items the player has to hold in their hand. This amount gets consumed
+ * output: the item stack the player gets when harvesting
+**/
+public class ColonyHarvestingRecipe implements Recipe<Inventory> {
+
+	// specifying a recipe with an empty ingredient marks it as the default recipe
+	// if no special recipe matches, this one is used as default
+	protected static ColonyHarvestingRecipe defaultRecipe;
+	protected static List<ColonyHarvestingRecipe> specialRecipes = new ArrayList<>();
+
+	protected final Identifier id;
+	protected final String group;
+	
+	protected final Ingredient hiveIngredient;
+	protected final Ingredient handIngredient;
+	protected final int handIngredientCount;
+	protected final ItemStack output;
+	
+	public ColonyHarvestingRecipe(Identifier id, String group, Ingredient hiveIngredient, Ingredient handIngredient, int handIngredientCount, ItemStack output) {
+		this.id = id;
+		this.group = group;
+		this.hiveIngredient = hiveIngredient;
+		this.handIngredient = handIngredient;
+		this.handIngredientCount = handIngredientCount;
+		this.output = output;
+		
+		if(this.hiveIngredient == Ingredient.EMPTY) {
+			defaultRecipe = this;
+		} else {
+			specialRecipes.add(this);
+		}
+	}
+	
+	@Override
+	public boolean equals(Object object) {
+		if (object instanceof ColonyHarvestingRecipe colonyHarvestingRecipe) {
+			return colonyHarvestingRecipe.getId().equals(this.getId());
+		}
+		return false;
+	}
+	
+	// we are using a custom match logic (the colonies are not inventories in the classical sense)
+	// => getRecipeFor()
+	@Override
+	public boolean matches(Inventory inv, World world) {
+		return false;
+	}
+	
+	@Override
+	public ItemStack craft(Inventory inv) {
+		return output;
+	}
+	
+	@Override
+	public boolean fits(int width, int height) {
+		return true;
+	}
+	
+	@Override
+	public ItemStack getOutput() {
+		return output;
+	}
+	
+	@Override
+	public boolean isIgnoredInRecipeBook() {
+		return true;
+	}
+	
+	@Override
+	public ItemStack createIcon() {
+		return new ItemStack(AntsBlocks.DIRT_ANT_NEST);
+	}
+	
+	@Override
+	public Identifier getId() {
+		return this.id;
+	}
+	
+	@Override
+	public RecipeSerializer<?> getSerializer() {
+		return AntsRecipeTypes.COLONY_HARVESTING_SERIALIZER;
+	}
+	
+	@Override
+	public RecipeType<?> getType() {
+		return AntsRecipeTypes.COLONY_HARVESTING;
+	}
+	
+	public static Optional<ColonyHarvestingRecipe> getRecipeFor(ItemStack hiveStack, ItemStack handStack) {
+		for(ColonyHarvestingRecipe recipe : specialRecipes) {
+			if(recipe.hiveIngredient.test(hiveStack) && recipe.handIngredient.test(handStack)) {
+				return Optional.of(recipe);
+			}
+		}
+		if(defaultRecipe.hiveIngredient.test(hiveStack) && defaultRecipe.handIngredient.test(handStack)) {
+			return Optional.of(defaultRecipe);
+		} else {
+			return Optional.empty();
+		}
+	}
+	
+	public int getHandIngredientCount() {
+		return this.handIngredientCount;
+	}
+	
+}

--- a/src/main/java/toxican/caleb/ants/recipes/ColonyHarvestingRecipe.java
+++ b/src/main/java/toxican/caleb/ants/recipes/ColonyHarvestingRecipe.java
@@ -111,11 +111,11 @@ public class ColonyHarvestingRecipe implements Recipe<Inventory> {
 	
 	public static Optional<ColonyHarvestingRecipe> getRecipeFor(ItemStack hiveStack, ItemStack handStack) {
 		for(ColonyHarvestingRecipe recipe : specialRecipes) {
-			if(recipe.hiveIngredient.test(hiveStack) && recipe.handIngredient.test(handStack)) {
+			if(recipe.hiveIngredient.test(hiveStack) && (recipe.handIngredient.isEmpty() || recipe.handIngredient.test(handStack))) {
 				return Optional.of(recipe);
 			}
 		}
-		if(defaultRecipe.hiveIngredient.test(hiveStack) && defaultRecipe.handIngredient.test(handStack)) {
+		if(defaultRecipe.handIngredient.isEmpty() || defaultRecipe.handIngredient.test(handStack)) {
 			return Optional.of(defaultRecipe);
 		} else {
 			return Optional.empty();

--- a/src/main/java/toxican/caleb/ants/recipes/ColonyHarvestingRecipeSerializer.java
+++ b/src/main/java/toxican/caleb/ants/recipes/ColonyHarvestingRecipeSerializer.java
@@ -20,8 +20,14 @@ public class ColonyHarvestingRecipeSerializer implements RecipeSerializer<Colony
 	@Override
 	public ColonyHarvestingRecipe read(Identifier identifier, JsonObject jsonObject) {
 		String group = JsonHelper.getString(jsonObject, "group", "");
-		Ingredient hiveIngredient = Ingredient.fromJson(JsonHelper.getObject(jsonObject, "hive_ingredient"));		
-		Ingredient handIngredient = Ingredient.fromJson(JsonHelper.getObject(jsonObject, "hand_ingredient"));		
+		Ingredient hiveIngredient = Ingredient.EMPTY;
+		if(jsonObject.has("hive_ingredient")) {
+			hiveIngredient = Ingredient.fromJson(JsonHelper.getObject(jsonObject, "hive_ingredient"));
+		}
+		Ingredient handIngredient = Ingredient.EMPTY;
+		if(jsonObject.has("hand_ingredient")) {
+			handIngredient = Ingredient.fromJson(JsonHelper.getObject(jsonObject, "hand_ingredient"));
+		}
 		int handIngredientCount = JsonHelper.getInt(jsonObject, "hand_ingredient_count", 1);
 		ItemStack output = ShapedRecipe.outputFromJson(JsonHelper.getObject(jsonObject, "result"));
 		

--- a/src/main/java/toxican/caleb/ants/recipes/ColonyHarvestingRecipeSerializer.java
+++ b/src/main/java/toxican/caleb/ants/recipes/ColonyHarvestingRecipeSerializer.java
@@ -1,0 +1,55 @@
+package toxican.caleb.ants.recipes;
+
+import com.google.gson.JsonObject;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.recipe.RecipeSerializer;
+import net.minecraft.recipe.ShapedRecipe;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+
+public class ColonyHarvestingRecipeSerializer implements RecipeSerializer<ColonyHarvestingRecipe> {
+	
+	public final RecipeFactory<ColonyHarvestingRecipe> recipeFactory;
+	
+	public ColonyHarvestingRecipeSerializer(RecipeFactory<ColonyHarvestingRecipe> recipeFactory) {
+		this.recipeFactory = recipeFactory;
+	}
+	
+	@Override
+	public ColonyHarvestingRecipe read(Identifier identifier, JsonObject jsonObject) {
+		String group = JsonHelper.getString(jsonObject, "group", "");
+		Ingredient hiveIngredient = Ingredient.fromJson(JsonHelper.getObject(jsonObject, "hive_ingredient"));		
+		Ingredient handIngredient = Ingredient.fromJson(JsonHelper.getObject(jsonObject, "hand_ingredient"));		
+		int handIngredientCount = JsonHelper.getInt(jsonObject, "hand_ingredient_count", 1);
+		ItemStack output = ShapedRecipe.outputFromJson(JsonHelper.getObject(jsonObject, "result"));
+		
+		return this.recipeFactory.create(identifier, group, hiveIngredient, handIngredient, handIngredientCount, output);
+	}
+	
+	@Override
+	public void write(PacketByteBuf packetByteBuf, ColonyHarvestingRecipe recipe) {
+		packetByteBuf.writeString(recipe.group);
+		recipe.hiveIngredient.write(packetByteBuf);
+		recipe.handIngredient.write(packetByteBuf);
+		packetByteBuf.writeInt(recipe.handIngredientCount);
+		packetByteBuf.writeItemStack(recipe.output);
+	}
+	
+	@Override
+	public ColonyHarvestingRecipe read(Identifier identifier, PacketByteBuf packetByteBuf) {
+		String group = packetByteBuf.readString();
+		Ingredient hiveIngredient = Ingredient.fromPacket(packetByteBuf);
+		Ingredient handIngredient = Ingredient.fromPacket(packetByteBuf);
+		int handIngredientCount = packetByteBuf.readInt();
+		ItemStack output = packetByteBuf.readItemStack();
+		
+		return this.recipeFactory.create(identifier, group, hiveIngredient, handIngredient, handIngredientCount, output);
+	}
+	
+	public interface RecipeFactory<ColonyHarvestingRecipe> {
+		ColonyHarvestingRecipe create(Identifier id, String group, Ingredient hiveIngredient, Ingredient handIngredient, int handIngredientCount, ItemStack output);
+	}
+	
+}

--- a/src/main/java/toxican/caleb/ants/recipes/ColonyShovelingRecipe.java
+++ b/src/main/java/toxican/caleb/ants/recipes/ColonyShovelingRecipe.java
@@ -1,0 +1,113 @@
+package toxican.caleb.ants.recipes;
+
+import net.minecraft.inventory.Inventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.recipe.Recipe;
+import net.minecraft.recipe.RecipeSerializer;
+import net.minecraft.recipe.RecipeType;
+import net.minecraft.util.Identifier;
+import net.minecraft.world.World;
+import toxican.caleb.ants.blocks.AntsBlocks;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Specifies the drop a player gets when using a shovel on a completely filled colony
+ * id: the recipes identifier
+ * group: internal group string (mainly used for the recipe book or other mechanisms that group recipes
+ * hiveIngredient: the last food the ants collected in that colony, or one per random
+ * output: the item stack the player gets when shoveling
+**/
+public class ColonyShovelingRecipe implements Recipe<Inventory> {
+
+	// specifying a recipe with an empty ingredient marks it as the default recipe
+	// if no special recipe matches, this one is used as default
+	protected static ColonyShovelingRecipe defaultRecipe;
+	protected static List<ColonyShovelingRecipe> specialRecipes = new ArrayList();
+
+	protected final Identifier id;
+	protected final String group;
+	
+	protected final Ingredient hiveIngredient;
+	protected final ItemStack output;
+	
+	public ColonyShovelingRecipe(Identifier id, String group, Ingredient hiveIngredient, ItemStack output) {
+		this.id = id;
+		this.group = group;
+		this.hiveIngredient = hiveIngredient;
+		this.output = output;
+		
+		if(this.hiveIngredient == Ingredient.EMPTY) {
+			defaultRecipe = this;
+		} else {
+			specialRecipes.add(this);
+		}
+	}
+	
+	@Override
+	public boolean equals(Object object) {
+		if (object instanceof ColonyShovelingRecipe colonyShovelingRecipe) {
+			return colonyShovelingRecipe.getId().equals(this.getId());
+		}
+		return false;
+	}
+	
+	// we are using a custom match logic (the colonies are not inventories in the classical sense)
+	// => getRecipeFor()
+	@Override
+	public boolean matches(Inventory inv, World world) {
+		return false;
+	}
+	
+	@Override
+	public ItemStack craft(Inventory inv) {
+		return output;
+	}
+	
+	@Override
+	public boolean fits(int width, int height) {
+		return true;
+	}
+	
+	@Override
+	public ItemStack getOutput() {
+		return output;
+	}
+	
+	@Override
+	public boolean isIgnoredInRecipeBook() {
+		return true;
+	}
+	
+	@Override
+	public ItemStack createIcon() {
+		return new ItemStack(AntsBlocks.DIRT_ANT_NEST);
+	}
+	
+	@Override
+	public Identifier getId() {
+		return this.id;
+	}
+	
+	@Override
+	public RecipeSerializer<?> getSerializer() {
+		return AntsRecipeTypes.COLONY_SHOVELING_SERIALIZER;
+	}
+	
+	@Override
+	public RecipeType<?> getType() {
+		return AntsRecipeTypes.COLONY_SHOVELING;
+	}
+	
+	public static ColonyShovelingRecipe getRecipeFor(ItemStack hiveStack) {
+		for(ColonyShovelingRecipe recipe : specialRecipes) {
+			if(recipe.hiveIngredient.test(hiveStack)) {
+				return recipe;
+			}
+		}
+		return defaultRecipe;
+	}
+	
+}

--- a/src/main/java/toxican/caleb/ants/recipes/ColonyShovelingRecipeSerializer.java
+++ b/src/main/java/toxican/caleb/ants/recipes/ColonyShovelingRecipeSerializer.java
@@ -1,0 +1,49 @@
+package toxican.caleb.ants.recipes;
+
+import com.google.gson.JsonObject;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.recipe.RecipeSerializer;
+import net.minecraft.recipe.ShapedRecipe;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+
+public class ColonyShovelingRecipeSerializer implements RecipeSerializer<ColonyShovelingRecipe> {
+	
+	public final RecipeFactory<ColonyShovelingRecipe> recipeFactory;
+	
+	public ColonyShovelingRecipeSerializer(RecipeFactory<ColonyShovelingRecipe> recipeFactory) {
+		this.recipeFactory = recipeFactory;
+	}
+	
+	@Override
+	public ColonyShovelingRecipe read(Identifier identifier, JsonObject jsonObject) {
+		String group = JsonHelper.getString(jsonObject, "group", "");
+		Ingredient hiveIngredient = Ingredient.fromJson(JsonHelper.getObject(jsonObject, "hive_ingredient"));		
+		ItemStack output = ShapedRecipe.outputFromJson(JsonHelper.getObject(jsonObject, "result"));
+		
+		return this.recipeFactory.create(identifier, group, hiveIngredient, output);
+	}
+	
+	@Override
+	public void write(PacketByteBuf packetByteBuf, ColonyShovelingRecipe recipe) {
+		packetByteBuf.writeString(recipe.group);
+		recipe.hiveIngredient.write(packetByteBuf);
+		packetByteBuf.writeItemStack(recipe.output);
+	}
+	
+	@Override
+	public ColonyShovelingRecipe read(Identifier identifier, PacketByteBuf packetByteBuf) {
+		String group = packetByteBuf.readString();
+		Ingredient hiveIngredient = Ingredient.fromPacket(packetByteBuf);
+		ItemStack output = packetByteBuf.readItemStack();
+		
+		return this.recipeFactory.create(identifier, group, hiveIngredient, output);
+	}
+	
+	public interface RecipeFactory<ColonyShovelingRecipe> {
+		ColonyShovelingRecipe create(Identifier id, String group, Ingredient hiveIngredient, ItemStack output);
+	}
+	
+}

--- a/src/main/java/toxican/caleb/ants/recipes/ColonyShovelingRecipeSerializer.java
+++ b/src/main/java/toxican/caleb/ants/recipes/ColonyShovelingRecipeSerializer.java
@@ -20,7 +20,10 @@ public class ColonyShovelingRecipeSerializer implements RecipeSerializer<ColonyS
 	@Override
 	public ColonyShovelingRecipe read(Identifier identifier, JsonObject jsonObject) {
 		String group = JsonHelper.getString(jsonObject, "group", "");
-		Ingredient hiveIngredient = Ingredient.fromJson(JsonHelper.getObject(jsonObject, "hive_ingredient"));		
+		Ingredient hiveIngredient = Ingredient.EMPTY;
+		if(jsonObject.has("hive_ingredient")) {
+			hiveIngredient = Ingredient.fromJson(JsonHelper.getObject(jsonObject, "hive_ingredient"));
+		}
 		ItemStack output = ShapedRecipe.outputFromJson(JsonHelper.getObject(jsonObject, "result"));
 		
 		return this.recipeFactory.create(identifier, group, hiveIngredient, output);

--- a/src/main/resources/data/ants/recipes/colony_harvesting/default_colony_harvesting.json
+++ b/src/main/resources/data/ants/recipes/colony_harvesting/default_colony_harvesting.json
@@ -1,7 +1,8 @@
 {
   "type": "ants:colony_harvesting",
-  "hive_ingredient": null,
-  "hand_ingredient": "minecraft:bottle",
+  "hand_ingredient": {
+    "item": "minecraft:glass_bottle"
+  },
   "hand_ingredient_count": 1,
   "result" : {
     "item": "ants:clay_bottle",

--- a/src/main/resources/data/ants/recipes/colony_harvesting/default_colony_harvesting.json
+++ b/src/main/resources/data/ants/recipes/colony_harvesting/default_colony_harvesting.json
@@ -1,0 +1,10 @@
+{
+  "type": "ants:colony_harvesting",
+  "hive_ingredient": null,
+  "hand_ingredient": "minecraft:bottle",
+  "hand_ingredient_count": 1,
+  "result" : {
+    "item": "ants:clay_bottle",
+	"count": 1
+  }
+}

--- a/src/main/resources/data/ants/recipes/colony_shoveling/default_colony_shoveling.json
+++ b/src/main/resources/data/ants/recipes/colony_shoveling/default_colony_shoveling.json
@@ -1,6 +1,5 @@
 {
   "type": "ants:colony_shoveling",
-  "hive_ingredient": null,
   "result" : {
     "item": "minecraft:clay_ball",
 	"count": 3

--- a/src/main/resources/data/ants/recipes/colony_shoveling/default_colony_shoveling.json
+++ b/src/main/resources/data/ants/recipes/colony_shoveling/default_colony_shoveling.json
@@ -1,0 +1,8 @@
+{
+  "type": "ants:colony_shoveling",
+  "hive_ingredient": null,
+  "result" : {
+    "item": "minecraft:clay_ball",
+	"count": 3
+  }
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,7 +34,8 @@
     "fabricloader": ">=0.13.3",
     "fabric": "*",
     "minecraft": "1.18.x",
-    "java": ">=17"
+    "java": ">=17",
+    "geckolib3": "*"
   },
   "suggests": {
     "another-mod": "*"


### PR DESCRIPTION
**2 new recipe types**
- ColonyShovelingRecipe: When using a shovel on a full hive, damaging the shovel
- ColonyHarvestingRecipe: When right clicking on a full hive with a specified item in the player's hand, consuming one or more of that item

For that, the colonies now remember the last leaf that was delivered to it.

The default drops of 3x clay ball / clay bottle are implemented via these new recipe types. Modpack makers and other mods can now add new drops, or modify the default recipe to alter the default drops via data pack. Since the colonies remember the last delivered leaf, you can also specify different drops based on what the ants collected (clay for oak trees, something else for spruce, ...)
I added a few more recipe examples in /example_recipes/. Feel free to delete / move them :)

<br>

**Updated dependencies**
- updated all dependencies to newer versions in gradle
- geckolib is now listed as a requirement in the mod.json. This way the player get's notified to install geckolib, instead of the game crashing

<br>

I added some documentation comments to the recipe classes. If I should add more documentation or change anything no prob!