### PR TITLE
Enchantment Descriptions Compat, Small Fixes & Other Stuff

### DIFF
--- a/src/main/java/toxican/caleb/ants/mixin/AntsMixin.java
+++ b/src/main/java/toxican/caleb/ants/mixin/AntsMixin.java
@@ -22,7 +22,7 @@ public class AntsMixin {
 		BlockState blockState = world.getBlockState(pos);
 		if(blockState.getBlock() == Blocks.DANDELION && world instanceof ServerWorld){
 			world.setBlockState(pos, AntsBlocks.WINDY_DANDELION.getDefaultState(), Block.NOTIFY_ALL);
+			stack.decrement(1);
 		}
-		stack.decrement(1);
 	}
 }

--- a/src/main/resources/assets/ants/lang/en_us.json
+++ b/src/main/resources/assets/ants/lang/en_us.json
@@ -12,6 +12,7 @@
     "block.ants.sand_ant_nest": "Sand Ant Colony",
     "block.ants.mud_ant_nest": "Mud Ant Colony",
     "block.ants.windy_dandelion": "Windy Dandelion",
+    "block.ants.potted_windy_dandelion": "Potted Windy Dandelion",
 
     "entity.ants.ant": "Ant",
 

--- a/src/main/resources/assets/ants/lang/en_us.json
+++ b/src/main/resources/assets/ants/lang/en_us.json
@@ -21,6 +21,7 @@
     "subtitles.ants.exit_nest": "Ant exits nest",
 
     "enchantment.ants.ant_resistance": "Nest Resistance",
+    "enchantment.ants.ant_resistance.desc": "Prevents you from taking damage from ant colonies",
 
     "death.attack.nest": "%1$s stood on an Ant Colony",
     "death.attack.nest.player": "%1$s stood on an Ant Colony",

--- a/src/main/resources/data/ants/loot_tables/blocks/potted_windy_dandelion.json
+++ b/src/main/resources/data/ants/loot_tables/blocks/potted_windy_dandelion.json
@@ -1,0 +1,35 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:flower_pot"
+        }
+      ],
+      "rolls": 1.0
+    },
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "ants:windy_dandelion"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/flower_pots.json
+++ b/src/main/resources/data/minecraft/tags/blocks/flower_pots.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "ants:potted_windy_dandelion"
+  ]
+}

--- a/src/main/resources/data/minecraft/tags/blocks/small_flowers.json
+++ b/src/main/resources/data/minecraft/tags/blocks/small_flowers.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+	"ants:windy_dandelion"
+  ]
+}


### PR DESCRIPTION
- [Added compat for **Enchantment Descriptions Mod**](https://github.com/MastroCaleb/Little-Ants/pull/6/commits/4f177c0e3acefd5f90fa85bfedfb9c1be1cfeb05)
![2023-01-20_08 44 32](https://user-images.githubusercontent.com/114457180/213594042-36f12de9-d01a-43e5-a0c9-08418362fe63.png)

- [Added **Windy Dandelion** to `minecraft:small_flowers` block tag](https://github.com/MastroCaleb/Little-Ants/pull/6/commits/5257d689fccd1e3279c18bd943aa07bc4b355298)

- [Fixed bone meal get consumed when right-clicking it with any other blocks](https://github.com/MastroCaleb/Little-Ants/pull/6/commits/961f56008a7b01d7f0619f4532115c1bc8d738f8)

- [Fixed missing block name for **Potted Windy Dandelion**](https://github.com/MastroCaleb/Little-Ants/pull/6/commits/5520fb05784d2144e737bfbaa96da7e11e4906b9)

- [Fixed missing loot table for **Potted Windy Dandelion**](https://github.com/MastroCaleb/Little-Ants/pull/6/commits/5643ccb3cca9c759636097aa8cee8fc5e53f11fd)

- [Added **Potted Windy Dandelion** to `minecraft:flower_pots` block tag](https://github.com/MastroCaleb/Little-Ants/pull/6/commits/1ce56cea067c42cf867b3bae15b03eddb6d59c0c)